### PR TITLE
Fix duplicate import and remove unused Thread

### DIFF
--- a/lambda_transcriptor.py
+++ b/lambda_transcriptor.py
@@ -1,10 +1,8 @@
 import time
 import os
 import logging
-from threading import Thread
 import whisper
 from whisper.model import ModelDimensions, Whisper
-import os
 import boto3
 import io
 import pickle


### PR DESCRIPTION
## Summary
- clean up imports in `lambda_transcriptor.py`

## Testing
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685bd33bec0c832884b635f5e97ac1c4