### PR TITLE
Fix transcriptor return and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ python -m unittest tests/test_add_subtitles.py
 python -m unittest tests/test_get_subtitles.py
 python -m unittest tests/test_extract_audio.py
 ```
+
+## Lambda output
+
+The `lambda_transcriptor` function uploads a TXT file with the transcription and
+an SRT file with subtitles to the configured S3 bucket. It returns a JSON body
+containing the bucket and the keys for these files.

--- a/lambda_transcriptor.py
+++ b/lambda_transcriptor.py
@@ -141,6 +141,20 @@ def lambda_handler(event, context):
     s3_client.upload_file(srt_file, AWS_BUCKET_NAME, s3_output_key_srt)
     logging.warning('SRT file uploaded to %s', s3_output_key_srt)
 
+    return {
+        'statusCode': 200,
+        'body': {
+            'text': {
+                'key': s3_output_key_txt,
+                'bucket': AWS_BUCKET_NAME,
+            },
+            'subtitles': {
+                'key': s3_output_key_srt,
+                'bucket': AWS_BUCKET_NAME,
+            }
+        }
+    }
+
 
 
 def save_transcription(data, srt_file):


### PR DESCRIPTION
## Summary
- return S3 output paths from `lambda_transcriptor`
- document transcriptor output
- patch subtitle polling tests to use patched s3 client

## Testing
- `python -m unittest tests/test_get_subtitles.py`
- `python -m unittest tests/test_extract_audio.py`
- `python -m unittest tests/test_add_subtitles.py`


------
https://chatgpt.com/codex/tasks/task_b_685bd39030708328b8f827ebbbca7dde